### PR TITLE
Textfield same width and style as input fields

### DIFF
--- a/common/static/css/vendor/normalize.css
+++ b/common/static/css/vendor/normalize.css
@@ -385,11 +385,19 @@ input::-moz-focus-inner {
 /**
  * 1. Remove default vertical scrollbar in IE 8/9.
  * 2. Improve readability and alignment in all browsers.
+ * 3. Width (plus padding) results in the same widht as input fields.
+ * 4. Same border and border-radius as input fields.
+ * 5. Minimum height height to make the textarea more apparent.
  */
 
 textarea {
     overflow: auto; /* 1 */
     vertical-align: top; /* 2 */
+    width: 43%; /* 3 */
+    padding: 1%;
+    border: 1px solid #b2b2b2; /* 4 */
+    border-radius: 3px;
+    min-height: 80px; /* 5 */
 }
 
 /* ==========================================================================


### PR DESCRIPTION


For consistency sake I feel this should be changed.
This:
![screenshot from 2015-06-11 10 47 45](https://cloud.githubusercontent.com/assets/2808092/8103334/f0674666-1027-11e5-8385-5173071a0289.png)

is better than this:
![screenshot from 2015-06-11 10 48 41](https://cloud.githubusercontent.com/assets/2808092/8103338/fd5d37ae-1027-11e5-9822-f5254b9a341b.png)
